### PR TITLE
Add trailing backtick to `npm install` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 `cd homes-app`
 
 - Install the depencies
-`npm install 
+`npm install`
 
 - Run the application 
 `ng serve`


### PR DESCRIPTION
## Pull Request - Adding trailing backtick to `npm install` instruction

### Description
Added a missing trailing backtick to the `npm install` instruction in the documentation.

### Changes Made
```markdown
`npm install`
```

### Related Issue
This pull request is not associated with any specific issue.

Thank you for considering this pull request!