### PR TITLE
Update cloning branch instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@
 
 - Clone this branch to your local machine
 
-  `git clone -b homes-app-start git@github.com:angular/codelabs.git homes-app`
+  `git clone -b homes-app-start git@github.com:angular/codelabs.git homes-app` (using SSH)
+  or
+  `git clone -b homes-app-start https://github.com/angular/codelabs.git homes-app` (using HTTPS)
 
 - Once the code has been downloaded
 
   `cd homes-app`
 
-- Install the depencies
+- Install the dependencies
 
   `npm install` 
 


### PR DESCRIPTION
Add the command to clone the branch via HTTPS, as there are many beginners who may not have SSH configured, and are thus encountering problems as seen in the comments under the tutorial videos